### PR TITLE
Migrate from deprecated apt key to deb822 repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ caddy_service_enabled: true
 caddy_restart_handler_state: restarted
 
 # Debian
-caddy_apt_repository: deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
+caddy_apt_repository_url: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+caddy_apt_repository_types: [deb]
+caddy_apt_repository_suites: [any-version]
+caddy_apt_repository_components: [main]
+
 caddy_apt_gpg_key: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
-caddy_apt_ignore_key_error: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 # handlers file for caddy
 - name: restart caddy
-  service: "name=caddy state={{ caddy_restart_handler_state }}"
+  ansible.builtin.service: "name=caddy state={{ caddy_restart_handler_state }}"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -8,16 +8,17 @@
       - curl
     state: present
 
-- name: Add Caddy apt key.
-  ansible.builtin.apt_key:
-    url: "{{ caddy_apt_gpg_key }}"
-    id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
+- name: Add caddy repository
+  ansible.builtin.deb822_repository:
+    name: caddy
+    uris: "{{ caddy_apt_repository_url }}"
+    signed_by: "{{ caddy_apt_gpg_key }}"
+    components: "{{ caddy_apt_repository_components }}"
+    suites: "{{ caddy_apt_repository_suites }}"
+    types: "{{ caddy_apt_repository_types }}"
     state: present
-  register: add_repository_key
-  ignore_errors: "{{ caddy_apt_ignore_key_error }}"
+    enabled: true
 
-- name: Add Caddy repository.
-  ansible.builtin.apt_repository:
-    repo: "{{ caddy_apt_repository }}"
-    state: present
+- name: Run the equivalent of "apt-get update"
+  ansible.builtin.apt:
     update_cache: true

--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -1,18 +1,17 @@
 ---
 - name: Install fedora copr plugin (dnf)
-  package:
+  ansible.builtin.package:
     name: dnf-command(copr)
     state: present
 
 - name: Enable caddy repo
-  command: dnf copr enable -y @caddy/caddy
+  ansible.builtin.command: dnf copr enable -y @caddy/caddy
   args:
-    warn: no
+    warn: false
   register: dnf_repo_enable
   changed_when: false
 
-
 - name: Install caddy package
-  dnf:
+  ansible.builtin.dnf:
     name: caddy
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # tasks file for caddy
 
-- include_tasks: fedora.yml
+- ansible.builtin.include_tasks: fedora.yml
   when: ansible_os_family == 'RedHat'
 
-- include_tasks: debian.yml
+- ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Caddy
-  package:
+  ansible.builtin.package:
     name: "{{  caddy_package }}"
     state: "{{ caddy_package_state }}"
   notify: restart caddy


### PR DESCRIPTION
apt prints deprecation warnings when apt_key + apt_repository are used
deb822_repository module seems to be a proper solution: https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible