### PR TITLE
Add changed_when false to apt update task

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -22,3 +22,4 @@
 - name: Run the equivalent of "apt-get update"
   ansible.builtin.apt:
     update_cache: true
+  changed_when: false


### PR DESCRIPTION
This task will (almost?) always result in a "changed" state which creates noise when running playbooks. Just an "ok" state should be sufficient feedback for the task.